### PR TITLE
fix(Query): skip subselect predicates for non-joining VirtualCube base cubes

### DIFF
--- a/mondrian/src/it/java/mondrian/rolap/VirtualCubeTest.java
+++ b/mondrian/src/it/java/mondrian/rolap/VirtualCubeTest.java
@@ -874,6 +874,39 @@ public class VirtualCubeTest extends BatchTestCase {
     }
 
     /**
+     * A subselect on a dimension that does not join to the underlying
+     * base cube of a VirtualCube measure must not constrain that base
+     * cube at all. Before the fix, {@code Query.getSubcubePredicates}
+     * walked the subselect member's hierarchy, called
+     * {@code getBaseStarKeyColumn(baseCube)} on each level, and handed
+     * the resulting null column straight into a
+     * {@code MemberColumnPredicate}, producing a broken predicate that
+     * either NPEd or generated invalid SQL against a base cube it
+     * should not have touched.
+     */
+    public void testSubselectOnInapplicableDimensionDoesNotConstrainMemberCube() {
+        final TestContext testContext = TestContext.instance();
+        final String queryWithoutSubselect =
+            "with member [Measures].[validUS] as "
+            + "'ValidMeasure([Measures].[Unit Sales])' "
+            + "select {[Measures].[validUS]} on columns "
+            + "from [Warehouse and Sales]";
+        final String queryWithSubselect =
+            "with member [Measures].[validUS] as "
+            + "'ValidMeasure([Measures].[Unit Sales])' "
+            + "select {[Measures].[validUS]} on columns "
+            + "from ("
+            + " select ({[Warehouse].[USA].[CA]}) on columns"
+            + " from [Warehouse and Sales]"
+            + ")";
+
+        assertQueriesReturnSimilarResults(
+            queryWithoutSubselect,
+            queryWithSubselect,
+            testContext);
+    }
+
+    /**
      * Checks that native set caching considers base cubes in the cache key.
      * Native sets referencing different base cubes do not share the cached
      * result.

--- a/mondrian/src/main/java/mondrian/olap/Query.java
+++ b/mondrian/src/main/java/mondrian/olap/Query.java
@@ -2545,6 +2545,7 @@ public class Query extends QueryPart {
                         mondrian.olap.MatchType.EXACT);
 
                 List<StarPredicate> memberAndList = new ArrayList<StarPredicate>();
+                boolean memberAppliesToBaseCube = true;
 
                 Member memberWalk = memberFromSubcube;
                 Level levelLast = null;
@@ -2553,13 +2554,25 @@ public class Query extends QueryPart {
                         RolapCubeMember rolapCubeMember = (RolapCubeMember) memberWalk;
                         RolapStar.Column column =
                             rolapCubeMember.getLevel().getBaseStarKeyColumn(baseCube);
+                        if (column == null) {
+                            // The current subselect hierarchy does not
+                            // join to this member's cube. For VirtualCube
+                            // semantics this means the subselect should
+                            // not constrain this base cube at all — drop
+                            // the whole member predicate rather than emit
+                            // a bogus (null-column) predicate that
+                            // corrupts downstream SQL generation.
+                            memberAppliesToBaseCube = false;
+                            memberAndList.clear();
+                            break;
+                        }
                         memberAndList.add(
                             new MemberColumnPredicate(column, rolapCubeMember));
                     }
                     levelLast = memberWalk.getLevel();
                     memberWalk = memberWalk.getParentMember();
                 }
-                if (memberAndList.size() > 0) {
+                if (memberAppliesToBaseCube && memberAndList.size() > 0) {
                     listOfSubcubeMembers.add(new AndPredicate(memberAndList));
                 }
             } else {


### PR DESCRIPTION
## Problem

When running a VirtualCube query that combines a subselect on a dimension that only applies to *one* of the underlying base cubes together with a `ValidMeasure(...)` over a measure from a *different* base cube, `Query.getSubcubePredicates` can return a corrupted predicate that over-restricts the wrong base cube.

Concretely:

```mdx
with member [Measures].[validUS] as
  'ValidMeasure([Measures].[Unit Sales])'
select {[Measures].[validUS]} on columns
from (
  select ({[Warehouse].[USA].[CA]}) on columns
  from [Warehouse and Sales]
)
```

Here:
- `[Unit Sales]` lives in the Sales base cube.
- `[Warehouse]` is a Warehouse-only dimension.
- `ValidMeasure` should strip the Warehouse context and return the unconstrained Sales total.

The expected semantics: the result should be identical to the query *without* the subselect, because the Warehouse subselect cannot constrain Sales — there is no join.

## Root cause

`Query.getSubcubePredicates` -> `addSetToSubcubePredicates` walks the subselect member up its hierarchy building `MemberColumnPredicate` for each level:

```java
RolapCubeMember rolapCubeMember = (RolapCubeMember) memberWalk;
RolapStar.Column column =
    rolapCubeMember.getLevel().getBaseStarKeyColumn(baseCube);
memberAndList.add(
    new MemberColumnPredicate(column, rolapCubeMember));
```

When the member's hierarchy does not join to `baseCube`, `getBaseStarKeyColumn(baseCube)` returns **null**. The unchecked null is then wrapped in a `MemberColumnPredicate`, which either:
- NPEs later, or
- gets serialized into SQL as a bogus predicate against `baseCube` that should not be constrained at all.

## Fix

Track a `memberAppliesToBaseCube` flag inside the hierarchy walk. If any level of the walked hierarchy has no base-star key column for the current base cube, drop the *whole* member predicate (it has no meaning for this base cube) and skip adding it to `listOfSubcubeMembers`. VirtualCube semantics are preserved: the subselect only constrains base cubes that share the subselect's dimension.

```diff
 List<StarPredicate> memberAndList = new ArrayList<StarPredicate>();
+boolean memberAppliesToBaseCube = true;

 Member memberWalk = memberFromSubcube;
 Level levelLast = null;
 while (memberWalk != null && !memberWalk.isAll()) {
     if (memberWalk.getLevel() != levelLast) {
         RolapCubeMember rolapCubeMember = (RolapCubeMember) memberWalk;
         RolapStar.Column column =
             rolapCubeMember.getLevel().getBaseStarKeyColumn(baseCube);
+        if (column == null) {
+            // The current subselect hierarchy does not join to this
+            // member's cube. For VirtualCube semantics this means the
+            // subselect should not constrain this base cube at all —
+            // drop the whole member predicate rather than emit a
+            // bogus (null-column) predicate that corrupts downstream
+            // SQL generation.
+            memberAppliesToBaseCube = false;
+            memberAndList.clear();
+            break;
+        }
         memberAndList.add(
             new MemberColumnPredicate(column, rolapCubeMember));
     }
     levelLast = memberWalk.getLevel();
     memberWalk = memberWalk.getParentMember();
 }
-if (memberAndList.size() > 0) {
+if (memberAppliesToBaseCube && memberAndList.size() > 0) {
     listOfSubcubeMembers.add(new AndPredicate(memberAndList));
 }
```

## Test

`VirtualCubeTest.testSubselectOnInapplicableDimensionDoesNotConstrainMemberCube` — asserts that a `ValidMeasure([Unit Sales])` query returns the same value with and without a `([Warehouse].[USA].[CA])` subselect. The test exercises the `[Warehouse and Sales]` VirtualCube that already lives in the FoodMart test schema.

## Scope

This is a **small, self-contained fix** — 14 lines in `Query.java` + 22 lines of test. It addresses one concrete VirtualCube bug discovered while debugging our fork's schema and does not depend on any other of our downstream patches.

A broader analysis of related subcube-predicate plumbing gaps from `29e42149 "sql subcube"` is in https://github.com/dronsv/mondrian/issues/10 — happy to open a follow-up PR or separate issue here if you'd like to review that cascade too.

— originally authored as [dronsv/mondrian@f5a2adf7](https://github.com/dronsv/mondrian/commit/f5a2adf7)